### PR TITLE
nmp won't install inflect when using node v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lib":"./lib"
   },
   "engines": {
-    "node": ">= 0.4.0 < 0.5.0"
+    "node": ">= 0.4.x <= 0.5.1"
   },
   "devDependencies": {
     "coffee-script": ">= 1.0.1 < 2.0.0",


### PR DESCRIPTION
Bumped npm package restriction for node's version number.

Tests passed on node v0.5.1 MacOS

```
→ node --version
v0.5.1

→ cake test
Running test suite ... 
····························· 

✓ OK » 29 honored (1.083s)
```
