### PR TITLE
Include client folder in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "LICENSE",
     "README.md",
     "spec",
-    "src"
+    "src",
+    "client"
   ],
   "scripts": {
     "build": "cake build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "README.md",
     "spec",
     "src",
-    "client",
+    "client"
   ],
   "scripts": {
     "build": "cake build",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "LICENSE",
     "README.md",
     "spec",
-    "src"
+    "src",
+    "client",
   ],
   "scripts": {
     "build": "cake build",


### PR DESCRIPTION
I was updating dependencies on one of our projects and gulp started complaining about a missing file 
```
Error: File not found with singular glob: /Users/acidburn/Code/some_repo/node_modules/inflect/client/inflect.min.js (if this was purposeful, use `allowEmpty` option)
```


We use to be able to `npm install inflect` and reference the minified client library in our gulp process like `'./node_modules/inflect/client/inflect.min.js'` 

I pulled up the repo on github and noticed the the client folder was still present on the github repo.

Then I looked at the `package.json` file and noticed client wasn't included there, so to test I forked the repo, added `"client"` to `files` section in the `package.json` and installed inflect directly from the repo and the file was present again.